### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/EvictATenant/data/questions/evict_a_tenant.yml
+++ b/docassemble/EvictATenant/data/questions/evict_a_tenant.yml
@@ -1042,9 +1042,9 @@ subquestion: |
 ---
 id: tenant contact information
 question: |
-  Tell us more about ${ other_parties[i].name.full(middle="full") }
+  Tell us more about ${ other_parties[i].name_full() }
 subquestion: |
-  Enter ${ other_parties[i].name.full(middle="full") }'s contact information, if you know it.
+  Enter ${ other_parties[i].name_full() }'s contact information, if you know it.
 fields:
   - Phone: other_parties[i].phone_number
     datatype: al_international_phone
@@ -1055,16 +1055,16 @@ fields:
 ---
 id: tenant alt address question
 question: |
-  Do you have another address where ${ other_parties[i].name.full(middle="full") } can be found?
+  Do you have another address where ${ other_parties[i].name_full() } can be found?
 subquestion: |
-  If the sheriff cannot find ${ other_parties[i].name.full(middle="full") } at ${ other_parties[0].address.on_one_line(bare=True) }, the sheriff can try to serve them at another location.
+  If the sheriff cannot find ${ other_parties[i].name_full() } at ${ other_parties[0].address.on_one_line(bare=True) }, the sheriff can try to serve them at another location.
 fields:
-  - Other address for ${other_parties[i].name.full(middle="full")}?: other_parties[i].has_alt_address
+  - Other address for ${other_parties[i].name_full()}?: other_parties[i].has_alt_address
     datatype: yesnoradio
 ---
 id: alt address
 question: |
-  What is the other address where ${ other_parties[i].name.full(middle="full") } can be found?
+  What is the other address where ${ other_parties[i].name_full() } can be found?
 fields:
   - Street address: other_parties[i].alt_address.address
     address autocomplete: True
@@ -1080,7 +1080,7 @@ id: tenant alt contact information
 question: |
   Other contact information
 subquestion: |
-  Enter ${ other_parties[i].name.full(middle="full") }'s other contact information, if you know it.
+  Enter ${ other_parties[i].name_full() }'s other contact information, if you know it.
 fields:
   - Phone: other_parties[i].mobile_number
     datatype: al_international_phone
@@ -1493,7 +1493,7 @@ id: e-signature
 question: |
   Do you want to add your e-signature to your Eviction Complaint?
 subquestion: |
-  This program can put “**/s/ ${users[0].name.full(middle='full')}**” where you would sign your name. The court will accept this as your signature.
+  This program can put “**/s/ ${users[0].name_full()}**” where you would sign your name. The court will accept this as your signature.
 
   If you do not add your **{e-signature}**, you must sign your paper forms before you file and deliver them.
 
@@ -1727,7 +1727,7 @@ attachment:
       - "cure_period": ${ cure_period }
       - "cure_allowed_no": ${ cure_allowed == False }
       - "lease_end_period": ${ lease_end_period }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1752,7 +1752,7 @@ attachment:
       - "five_day_notice_checkbox": ${ True if notice_period == 5 else False }
       - "other_notice_checkbox": ${ True if notice_period != 5 else False }
       - "notice_period": ${ notice_period if notice_period != 5 else "" }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1774,7 +1774,7 @@ attachment:
       - "property_street_address__2": ${ other_parties[0].address.address }
       - "property_unit__2": ${ other_parties[0].address.unit }
       - "property_address_csz__2": ${ other_parties[0].address.line_two() }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1795,7 +1795,7 @@ attachment:
       - "property_street_address__2": ${ other_parties[0].address.address }
       - "property_unit__2": ${ other_parties[0].address.unit }
       - "property_address_csz__2": ${ other_parties[0].address.line_two() }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1844,8 +1844,8 @@ attachment:
       - "affidavit_no_attach_checkbox": ${ True if attach_notice == "No" or attach_service == "No" or attach_lease == "No" or attach_other == "No" else "" }
       - "other_attach_checkbox": ${ True if attach_other == "Yes" else False }
       - "other_supporting_documents": ${ other_attachments }
-      - "e_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "e_signature": ${ users[0].name_full() if e_signature else '' }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1879,8 +1879,8 @@ attachment:
       - "lease_lost_checkbox": ${ lease_lost if attach_lease == "No" else "" }
       - "lease_other_checkbox": ${ lease_not_attached_other if attach_lease == "No" else "" }
       - "lease_other_reason": ${ lease_not_attached_other_reason if (lease_not_attached_other and attach_lease == "No") else "" }
-      - "e_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "e_signature": ${ users[0].name_full() if e_signature else '' }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1900,12 +1900,12 @@ attachment:
       - "plaintiffs": ${ users.full_names() }
       - "defendants": ${ other_parties.full_names() }
       - "unknown_checkbox": ${ unknown_occupants }
-      - "tenant_name__1": ${ other_parties[0].name.full(middle="full") }
+      - "tenant_name__1": ${ other_parties[0].name_full() }
       - "service_address_street": ${ other_parties[0].address.line_one(bare=True) }
       - "service_address_csz": ${ other_parties[0].address.line_two() }
       - "tenant_phone": ${ phone_number_formatted(other_parties[0].phone_number) }
       - "tenant_email": ${ other_parties[0].email }
-      - "tenant_name__2": ${ other_parties[0].name.full(middle="full") if other_parties[0].has_alt_address else "" }
+      - "tenant_name__2": ${ other_parties[0].name_full() if other_parties[0].has_alt_address else "" }
       - "alt_service_address_street": ${ other_parties[0].alt_address.line_one(bare=True) if other_parties[0].has_alt_address else "" }
       - "alt_service_address_csz": ${ other_parties[0].alt_address.line_two()  if other_parties[0].has_alt_address else ""}
       - "alt_tenant_phone": ${ phone_number_formatted(other_parties[0].mobile_number) if other_parties[0].has_alt_address else "" }
@@ -1922,7 +1922,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1944,12 +1944,12 @@ attachment:
       - "plaintiffs": ${ users.full_names() }
       - "defendants": ${ other_parties.full_names() }
       - "unknown_checkbox": ${ unknown_occupants }
-      - "tenant_name__1": ${ other_parties[1].name.full(middle="full") }
+      - "tenant_name__1": ${ other_parties[1].name_full() }
       - "service_address_street": ${ other_parties[0].address.line_one(bare=True) }
       - "service_address_csz": ${ other_parties[0].address.line_two() }
       - "tenant_phone": ${ phone_number_formatted(other_parties[1].phone_number) }
       - "tenant_email": ${ other_parties[1].email }
-      - "tenant_name__2": ${ other_parties[1].name.full(middle="full") if other_parties[1].has_alt_address else "" }
+      - "tenant_name__2": ${ other_parties[1].name_full() if other_parties[1].has_alt_address else "" }
       - "alt_service_address_street": ${ other_parties[1].alt_address.line_one(bare=True) if other_parties[1].has_alt_address else "" }
       - "alt_service_address_csz": ${ other_parties[1].alt_address.line_two()  if other_parties[1].has_alt_address else ""}
       - "alt_tenant_phone": ${ phone_number_formatted(other_parties[1].mobile_number) if other_parties[1].has_alt_address else "" }
@@ -1966,7 +1966,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -1988,12 +1988,12 @@ attachment:
       - "plaintiffs": ${ users.full_names() }
       - "defendants": ${ other_parties.full_names() }
       - "unknown_checkbox": ${ unknown_occupants }
-      - "tenant_name__1": ${ other_parties[2].name.full(middle="full") }
+      - "tenant_name__1": ${ other_parties[2].name_full() }
       - "service_address_street": ${ other_parties[0].address.line_one(bare=True) }
       - "service_address_csz": ${ other_parties[0].address.line_two() }
       - "tenant_phone": ${ phone_number_formatted(other_parties[2].phone_number) }
       - "tenant_email": ${ other_parties[2].email }
-      - "tenant_name__2": ${ other_parties[2].name.full(middle="full") if other_parties[2].has_alt_address else "" }
+      - "tenant_name__2": ${ other_parties[2].name_full() if other_parties[2].has_alt_address else "" }
       - "alt_service_address_street": ${ other_parties[2].alt_address.line_one(bare=True) if other_parties[2].has_alt_address else "" }
       - "alt_service_address_csz": ${ other_parties[2].alt_address.line_two()  if other_parties[2].has_alt_address else ""}
       - "alt_tenant_phone": ${ phone_number_formatted(other_parties[2].mobile_number) if other_parties[2].has_alt_address else "" }
@@ -2010,7 +2010,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2032,12 +2032,12 @@ attachment:
       - "plaintiffs": ${ users.full_names() }
       - "defendants": ${ other_parties.full_names() }
       - "unknown_checkbox": ${ unknown_occupants }
-      - "tenant_name__1": ${ other_parties[3].name.full(middle="full") }
+      - "tenant_name__1": ${ other_parties[3].name_full() }
       - "service_address_street": ${ other_parties[0].address.line_one(bare=True) }
       - "service_address_csz": ${ other_parties[0].address.line_two() }
       - "tenant_phone": ${ phone_number_formatted(other_parties[3].phone_number) }
       - "tenant_email": ${ other_parties[3].email }
-      - "tenant_name__2": ${ other_parties[3].name.full(middle="full") if other_parties[3].has_alt_address else "" }
+      - "tenant_name__2": ${ other_parties[3].name_full() if other_parties[3].has_alt_address else "" }
       - "alt_service_address_street": ${ other_parties[3].alt_address.line_one(bare=True) if other_parties[3].has_alt_address else "" }
       - "alt_service_address_csz": ${ other_parties[3].alt_address.line_two()  if other_parties[3].has_alt_address else ""}
       - "alt_tenant_phone": ${ phone_number_formatted(other_parties[3].mobile_number) if other_parties[3].has_alt_address else "" }
@@ -2054,7 +2054,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2076,12 +2076,12 @@ attachment:
       - "plaintiffs": ${ users.full_names() }
       - "defendants": ${ other_parties.full_names() }
       - "unknown_checkbox": ${ unknown_occupants }
-      - "tenant_name__1": ${ other_parties[4].name.full(middle="full") }
+      - "tenant_name__1": ${ other_parties[4].name_full() }
       - "service_address_street": ${ other_parties[0].address.line_one(bare=True) }
       - "service_address_csz": ${ other_parties[0].address.line_two() }
       - "tenant_phone": ${ phone_number_formatted(other_parties[4].phone_number) }
       - "tenant_email": ${ other_parties[4].email }
-      - "tenant_name__2": ${ other_parties[4].name.full(middle="full") if other_parties[4].has_alt_address else "" }
+      - "tenant_name__2": ${ other_parties[4].name_full() if other_parties[4].has_alt_address else "" }
       - "alt_service_address_street": ${ other_parties[4].alt_address.line_one(bare=True) if other_parties[4].has_alt_address else "" }
       - "alt_service_address_csz": ${ other_parties[4].alt_address.line_two()  if other_parties[4].has_alt_address else ""}
       - "alt_tenant_phone": ${ phone_number_formatted(other_parties[4].mobile_number) if other_parties[4].has_alt_address else "" }
@@ -2098,7 +2098,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2142,7 +2142,7 @@ attachment:
       - "courthouse_address": ${ courthouse_info }
       - "clerk_phone": ${ trial_court.phone }
       - "clerk_website": ${ trial_court.website }
-      - "landlord_name": ${ users[0].name.full(middle="full") }
+      - "landlord_name": ${ users[0].name_full() }
       - "landlord_address_line_1": ${ users[0].address.line_one(bare=True) }
       - "landlord_address_csz": ${ users[0].address.line_two() }
       - "landlord_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2255,7 +2255,7 @@ review:
       **Tenants: (Edit to change names and contact info)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: forms_to_assemble
     button: |
@@ -2430,7 +2430,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: users[0].address.address
     button: |
       **Your address:**
@@ -2499,7 +2499,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - Contact and service info: |
       action_button_html(url_action(row_item.attr_name("review_tenant_info")), label="Edit", icon="pencil-alt")
 delete buttons: True
@@ -2510,33 +2510,33 @@ continue button field: x.review_tenant_info
 section: Basic info
 generic object: ALIndividual
 question: |
-  Edit ${ x.name.full(middle="full") }'s information
+  Edit ${ x.name_full() }'s information
 review: 
   - Edit: x.name.first
     button: |
       **Tenant name:**
-      ${ x.name.full(middle="full")  }
+      ${ x.name_full()  }
   - Edit: x.phone_number
     button: |
-      **${ x.name.full(middle="full") }'s phone number:**
+      **${ x.name_full() }'s phone number:**
       ${ phone_number_formatted(x.phone_number) }
   - Edit: x.email
     button: |
-      **${ x.name.full(middle="full") }'s email:**
+      **${ x.name_full() }'s email:**
       ${ x.email }
   - Edit: x.alt_address.address
     button: |
-      **${ x.name.full(middle="full") }'s alternate address:**
+      **${ x.name_full() }'s alternate address:**
       ${ x.alt_address.on_one_line(bare=True) }
     show if: x.has_alt_address
   - Edit: x.mobile_number
     button: |
-      **${ x.name.full(middle="full") }'s alternate phone number:**
+      **${ x.name_full() }'s alternate phone number:**
       ${ phone_number_formatted(x.mobile_number) }
     show if: x.has_alt_address
   - Edit: x.alt_email
     button: |
-      **${ x.name.full(middle="full") }'s alternate email:**
+      **${ x.name_full() }'s alternate email:**
       ${ x.alt_email }
     show if: x.has_alt_address
 ---
@@ -2581,7 +2581,7 @@ review:
       % endif
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
 ---
 id: eviction details review screen
@@ -2820,7 +2820,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: users[0].address.address
     button: |
       **Your address:**


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>